### PR TITLE
feat: add options to overrive response body on startup & and allow to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ const maintenance = new ExpressMaintenanceMode<MaintenanceResponseBody>({
     // Your method to set external state
   },
   localMaintenanceStateTTL: 6000 // Lifetime of local maintenance state, until it be synced with external state
+  maintenanceResponseOptions: { // Optional
+    statusCode: 302, // Default to 503
+    body: fs.readdirSync('path/to/maintenance/index.html').toString()
+  }
 });
 
 // Optional

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,12 @@ export class ExpressMaintenance<
         options.getExternalMaintenanceState ?? this.getExternalMaintenanceState;
       this.setExternalMaintenanceState =
         options.setExternalMaintenanceState ?? this.setExternalMaintenanceState;
+      if (options.maintenanceResponseOptions) {
+        this.maintenanceResponseOptions = {
+          ...this.maintenanceResponseOptions,
+          ...options.maintenanceResponseOptions
+        };
+      }
     }
 
     this.lastStateUpdateTimestamp = new Date();
@@ -39,6 +45,10 @@ export class ExpressMaintenance<
 
       if (this.isServerInMaintenanceMode() && this.isApiRequest(request)) {
         response.status(this.maintenanceResponseOptions.statusCode);
+        if (typeof this.maintenanceResponseOptions.body === 'string') {
+          return response.send(this.maintenanceResponseOptions.body);
+        }
+
         return response.json(this.maintenanceResponseOptions.body);
       }
 
@@ -195,7 +205,7 @@ export interface MaintenanceResponseOptions<
   MaintenanceResponseBody extends Record<string, any>
 > {
   statusCode?: number;
-  body?: MaintenanceResponseBody;
+  body?: MaintenanceResponseBody | any;
 }
 
 export interface ExpressMaintenanceOptions<
@@ -207,4 +217,5 @@ export interface ExpressMaintenanceOptions<
   localMaintenanceStateTTL?: number;
   getExternalMaintenanceState?: GetExternalMaintenanceStateFunction<MaintenanceResponseBody>;
   setExternalMaintenanceState?: SetExternalMaintenanceStateFunction<MaintenanceResponseBody>;
+  maintenanceResponseOptions?: MaintenanceResponseOptions<MaintenanceResponseBody>;
 }


### PR DESCRIPTION
… serve response body as text

So an html content can be served when on maintenance

Resolves #4 